### PR TITLE
fix keyboard layouts path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ En second lieu, je chercherai à faire reconnaître à l'OS que le layout est au
 # Installation
 Cloner le repository dans **/Library/Keyboard Layouts/fr-dvorak-bepo.bundle**
 ```
- cd /Library Keyboard\ Layouts
+ cd /Library/Keyboard\ Layouts
  git clone https://github.com/woyczek/fr-dvorak-bepo-apple fr-dvorak-bepo.bundle
 ``` 
 et relancer la session


### PR DESCRIPTION
A small fix for the MacOS path to the keyboard layouts directory.

Thanks for you work, it saves me when using Intellij code editors based on Java :)